### PR TITLE
Add exclude-current to inputs in action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -11,12 +11,13 @@ branding:
   icon: settings
 
 inputs:
-  healthchecks: { default:   "20", description: "Number of mirrors from the mirrors list to check for availability and up-to-dateness." }
-  speedtests:   { default:   "10", description: "Maximum number of healthy mirrors to test for speed." }
-  parallel:     { default:    "2", description: "Number of parallel speed tests. May result in incorrect results because of competing connections but finds a suitable mirror faster." }
-  sample-size:  { default: "1024", description: "Number of kilobytes to download during the speed from each mirror." }
-  sample-time:  { default:    "3", description: "Maximum number of seconds within the sample download from a mirror must finish." }
-
+  healthchecks:     { default:   "20", description: "Number of mirrors from the mirrors list to check for availability and up-to-dateness." }
+  speedtests:       { default:   "10", description: "Maximum number of healthy mirrors to test for speed." }
+  parallel:         { default:    "2", description: "Number of parallel speed tests. May result in incorrect results because of competing connections but finds a suitable mirror faster." }
+  sample-size:      { default: "1024", description: "Number of kilobytes to download during the speed from each mirror." }
+  sample-time:      { default:    "3", description: "Maximum number of seconds within the sample download from a mirror must finish." }
+  exclude-current:  { default:    "false", description: "Don't include the current APT mirror in the speed tests." }
+  
   repo-name:   { default: "vegardit/fast-apt-mirror.sh", description: "Repository containing the fast-apt-mirror.sh script" }
   repo-branch: { default: "v1", description: "Version (i.e. github branch) of the fast-apt-mirror.sh script to use" }
 
@@ -43,7 +44,8 @@ runs:
               --speedtests   ${{ inputs.speedtests }} \
               --parallel     ${{ inputs.parallel }} \
               --sample-size  ${{ inputs.sample-size }} \
-              --sample-time  ${{ inputs.sample-time }}
+              --sample-time  ${{ inputs.sample-time }} \
+              ${{ inputs.exclude-current && '--exclude-current' || '' }}
           fi || exit 0 # don't fail action if APT mirror detection failed for whatever reason
         fi
 


### PR DESCRIPTION
**Issue #, if available:**  
No specific issue referenced.

**Description of changes:**  
This pull request introduces the `exclude-current` input parameter to the `fast-apt-mirror.sh` action. This addition allows users to exclude the currently configured APT mirror from the speed tests, enhancing flexibility and control in mirror selection.

Key changes:
1. Added `exclude-current` input to `action.yml` with a default value of `false`.
2. Modified the script logic to include the `--exclude-current` flag when this input is enabled.
3. Updated descriptions in the input section for clarity.