### PR TITLE
Update action.yml

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -33,6 +33,16 @@ runs:
         echo "::group::Linux: Configure fast APT mirror"
         set -euo pipefail
 
+        # Step to get country code if not provided
+        if [[ -z "${{ inputs.country }}" ]]; then
+          echo "No country code provided, retrieving from public IP..."
+          IP_ADDRESS=$(curl -s http://checkip.amazonaws.com)
+          COUNTRY_CODE=$(curl -s http://ip-api.com/json/$IP_ADDRESS | jq -r '.countryCode')
+          echo "Detected country code: $COUNTRY_CODE"
+        else
+          COUNTRY_CODE="${{ inputs.country }}"
+        fi
+
         echo 'APT::Acquire::Retries "3";' | sudo tee /etc/apt/apt.conf.d/80-acquire-retries
 
         if [[ "${{ env.ACT }}" != "true" ]]; then
@@ -47,7 +57,7 @@ runs:
               --parallel     ${{ inputs.parallel }} \
               --sample-size  ${{ inputs.sample-size }} \
               --sample-time  ${{ inputs.sample-time }} \
-              --country      ${{ inputs.country }} \
+              --country      "$COUNTRY_CODE" \ 
               ${{ inputs.exclude-current && '--exclude-current' || '' }}
           fi || exit 0 # don't fail action if APT mirror detection failed for whatever reason
         fi

--- a/action.yml
+++ b/action.yml
@@ -17,6 +17,8 @@ inputs:
   sample-size:      { default: "1024", description: "Number of kilobytes to download during the speed from each mirror." }
   sample-time:      { default:    "3", description: "Maximum number of seconds within the sample download from a mirror must finish." }
   exclude-current:  { default:    "false", description: "Don't include the current APT mirror in the speed tests." }
+  country:          { default:    "", description: "The country code to use for selecting mirrors. NOTE: Only applies to Ubuntu based distros. Defaults to http://mirrors.ubuntu.com/mirrors.txt"" }
+
   
   repo-name:   { default: "vegardit/fast-apt-mirror.sh", description: "Repository containing the fast-apt-mirror.sh script" }
   repo-branch: { default: "v1", description: "Version (i.e. github branch) of the fast-apt-mirror.sh script to use" }
@@ -45,6 +47,7 @@ runs:
               --parallel     ${{ inputs.parallel }} \
               --sample-size  ${{ inputs.sample-size }} \
               --sample-time  ${{ inputs.sample-time }} \
+              --country      ${{ inputs.country }} \
               ${{ inputs.exclude-current && '--exclude-current' || '' }}
           fi || exit 0 # don't fail action if APT mirror detection failed for whatever reason
         fi


### PR DESCRIPTION
added country to the action file.
tested and work with empty country code to take the default one http://mirrors.ubuntu.com/mirrors.txt


the second commit adds an option to check where the machine is running and pass it to the command.
this is usable when running on github action runner which can be ran from anywhere. 