### PR TITLE
Handles cases where multiple "release" files with "ID=" lines exist.

### DIFF
--- a/fast-apt-mirror.sh
+++ b/fast-apt-mirror.sh
@@ -28,7 +28,7 @@ set -uo pipefail
 
 readonly RC_INVALID_ARGS=3
 readonly RC_MISC_ERROR=222
-
+declare -ar SUPPORTED_DISTRO_NAMES=("debian" "kali" "ubuntu" "pop")
 
 #################################################
 # configure logging/error reporting
@@ -85,7 +85,19 @@ function assert_option_is_int() {
 
 function get_dist_name() {
   if compgen -G "/etc/*-release" >/dev/null; then
-    awk -F= '/^ID=/ { print $2; exit }' /etc/*-release
+    readarray -t discovered_dist_names < <(awk -F= '/^ID=/ { print $2 }' /etc/*-release)
+    local found_distro_name=1
+    for discovered_name in "${discovered_dist_names[@]}"; do
+      for supported_name in "${SUPPORTED_DISTRO_NAMES[@]}"; do
+        if [[ "$discovered_name" = "$supported_name" ]]; then
+          found_distro_name=0
+          echo "$discovered_name"
+        fi
+      done
+    done
+    if [[ "$found_distro_name" = "1" ]]; then
+      echo "$OSTYPE"
+    fi
   else
     echo "$OSTYPE"
   fi


### PR DESCRIPTION
This will read all the "ID=" lines from all the "release" files and compare them with a list of supported distro names. If one matches, it will be returned. If no matches are found, it falls back to the default behavior of returning "$OSTYPE".

This has been tested and works in Debian 12, Ubuntu 22.04, and Ubuntu 24.04.

Fixes #12

