### PR TITLE
README.md: add deps to GitHub action section

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+    - name: Install fast-apt-mirror's dependencies
+      run: |
+        apt update --yes && apt install --yes --no-install-recommends jq curl sudo
     - name: Configure Fast APT Mirror
       uses: vegardit/fast-apt-mirror.sh@v1
       with: # the following parameters are listed with their action default values and are optional


### PR DESCRIPTION
Using the Github action like it's explained in the README was not enough, because you need to install the deps as well. This would save some time to people tinkering with this for the first time.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
